### PR TITLE
Link to 1hgj IRC channel instead of ludumdare

### DIFF
--- a/template/header.html
+++ b/template/header.html
@@ -6,7 +6,7 @@
 				<h1 style='margin-top: 0px;'>One hour game jam</h1>
 				A weekly one hour game jam.<br />
 				Each Saturday at 20:00 GMT.<br />
-				Join us on IRC: <a href='irc:afternet.org/ludumdare'>#ludumdare</a> channel on <a href='http://afternet.org'>afternet.org</a>
+				Join us on IRC: <a href='irc:afternet.org/1hgj'>#1hgj</a> channel on <a href='http://afternet.org'>afternet.org</a>
 			</div>
 		</div>
 	</div>


### PR DESCRIPTION
This PR changes the link in the header from the #ludumdare IRC channel to the #1hgj IRC channel.