### PR TITLE
Issue #28: Ability to edit old entries

### DIFF
--- a/template/author.html
+++ b/template/author.html
@@ -39,6 +39,10 @@
 							{{#has_url_android}}<a href='#' onclick='window.open("{{url_android}}", "_blank");'><img src='{{{template_path}}}images/platforms/android.png' style='width: 16px;' title='Android'></a>{{/has_url_android}}
 							{{#has_url_ios}}<a href='#' onclick='window.open("{{url_ios}}", "_blank");'><img src='{{{template_path}}}images/platforms/ios.png' style='width: 16px;' title='iOS'></a>{{/has_url_ios}}
 							{{#has_url}}<a href='#' onclick='window.open("{{url}}", "_blank");'><img src='{{{template_path}}}images/platforms/custom.png' style='width: 16px;' title='Other platform'></a>{{/has_url}}
+
+							{{#show_edit_link}}
+							<a href="?page=submit&amp;jam_number={{jam_number}}" class="btn btn-default">Edit entry</a>
+							{{/show_edit_link}}
 						</td>
 					</tr>
 					<tr>

--- a/template/submit.html
+++ b/template/submit.html
@@ -2,87 +2,100 @@
 	<p>
 		<h3>Submit your entry</h3>
 	</p>
-	<form method='post' enctype="multipart/form-data">
-		<div class="form-group">
-			<label for="gamename">Game name</label>
-			<input type="text" class="form-control" id="gamename" name='gamename' placeholder="Game name" value="{{user_entry_name}}" required>
+
+	<div class="panel panel-info jamContener">
+		<div class='panel-heading'>
+			<h3 class='panel-title' style='font-size: 24px;'>
+				{{submit_jam.jam_number_ordinal}} one hour game jam ({{submit_jam.date}})
+			</h3>
+			Theme: {{submit_jam.theme}}
 		</div>
-		
-		<b>Link to game</b>
-		<br />Add at least one. Leave blank to remove. If your game supports multiple platforms, insert the URL in fields for all supported platforms.
-		<div class="form-group">
-			<span style="{{#user_has_url_web}}display: none; {{/user_has_url_web}}">
-				<a href='#' onclick='ToggleURLEntry($(this));'>Add web build</a>
-			</span>
-			<span style="{{^user_has_url_web}}display: none; {{/user_has_url_web}}">
-				<label for="gameurlweb">URL to web build</label>
-				<input type="url" class="form-control" id="gameurlweb" name='gameurlweb' placeholder="http://game-url" value="{{user_entry_url_web}}">
-			</span>
-		</div>
-		<div class="form-group">
-			<span style="{{#user_has_url_windows}}display: none; {{/user_has_url_windows}}">
-				<a href='#' onclick='ToggleURLEntry($(this));'>Add Windows build</a>
-			</span>
-			<span style="{{^user_has_url_windows}}display: none; {{/user_has_url_windows}}">
-				<label for="gameurlwin">URL to Windows build</label>
-				<input type="url" class="form-control" id="gameurlwin" name='gameurlwin' placeholder="http://game-url" value="{{user_entry_url_windows}}">
-			</span>
-		</div>
-		<div class="form-group">
-			<span style="{{#user_has_url_mac}}display: none; {{/user_has_url_mac}}">
-				<a href='#' onclick='ToggleURLEntry($(this));'>Add Mac build</a>
-			</span>
-			<span style="{{^user_has_url_mac}}display: none; {{/user_has_url_mac}}">
-				<label for="gameurlmac">URL to Mac build</label>
-				<input type="url" class="form-control" id="gameurlmac" name='gameurlmac' placeholder="http://game-url" value="{{user_entry_url_mac}}">
-			</span>
-		</div>
-		<div class="form-group">
-			<span style="{{#user_has_url_linux}}display: none; {{/user_has_url_linux}}">
-				<a href='#' onclick='ToggleURLEntry($(this));'>Add Linux build</a>
-			</span>
-			<span style="{{^user_has_url_linux}}display: none; {{/user_has_url_linux}}">
-				<label for="gameurllinux">URL to Linux build</label>
-				<input type="url" class="form-control" id="gameurllinux" name='gameurllinux' placeholder="http://game-url" value="{{user_entry_url_linux}}">
-			</span>
-		</div>
-		<div class="form-group">
-			<span style="{{#user_has_url_ios}}display: none; {{/user_has_url_ios}}">
-				<a href='#' onclick='ToggleURLEntry($(this));'>Add iOS build</a>
-			</span>
-			<span style="{{^user_has_url_ios}}display: none; {{/user_has_url_ios}}">
-				<label for="gameurlios">URL to iOS build</label>
-				<input type="url" class="form-control" id="gameurlios" name='gameurlios' placeholder="http://game-url" value="{{user_entry_url_ios}}">
-			</span>
-		</div>
-		<div class="form-group">
-			<span style="{{#user_has_url_android}}display: none; {{/user_has_url_android}}">
-				<a href='#' onclick='ToggleURLEntry($(this));'>Add Android build</a>
-			</span>
-			<span style="{{^user_has_url_android}}display: none; {{/user_has_url_android}}">
-				<label for="gameurlandroid">URL to Android build</label>
-				<input type="url" class="form-control" id="gameurlandroid" name='gameurlandroid' placeholder="http://game-url" value="{{user_entry_url_android}}">
-			</span>
-		</div>
-		<div class="form-group">
-			<span style="{{#user_has_url}}display: none; {{/user_has_url}}">
-				<a href='#' onclick='ToggleURLEntry($(this));'>Add build for another platform</a>
-			</span>
-			<span style="{{^user_has_url}}display: none; {{/user_has_url}}">
-				<label for="gameurl">URL to build for another platform</label>
-				<input type="url" class="form-control" id="gameurl" name='gameurl' placeholder="http://game-url" value="{{user_entry_url}}">
-			</span>
-		</div>
-		<div class="form-group">
-			<label for="screenshotfile">Screenshot (Change)</label>
-			<input type="file" class="form-control" id="screenshotfile" name='screenshotfile' placeholder="Screenshot file" value="{{user_entry_screenshot}}">
-		</div>
-		<div class="form-group">
-			<label for="description">Brief game description</label>
-			<textarea class="form-control" id="description" name='description' placeholder="Game description">{{user_entry_desc}}</textarea>
-		</div>
-		<button type="submit" name='action' value='submit' class="btn btn-default">Submit</button>
-	</form>
+
+		<form method='post' enctype="multipart/form-data" class="panel-body jamContent">
+			<div class="form-group">
+				<label for="gamename">Game name</label>
+				<input type="text" class="form-control" id="gamename" name='gamename' placeholder="Game name" value="{{user_entry_name}}" required>
+ 			</div>
+			
+			<b>Link to game</b>
+			<br />Add at least one. Leave blank to remove. If your game supports multiple platforms, insert the URL in fields for all supported platforms.
+			<div class="form-group">
+				<span style="{{#user_has_url_web}}display: none; {{/user_has_url_web}}">
+					<a href='#' onclick='ToggleURLEntry($(this));'>Add web build</a>
+				</span>
+				<span style="{{^user_has_url_web}}display: none; {{/user_has_url_web}}">
+					<label for="gameurlweb">URL to web build</label>
+					<input type="url" class="form-control" id="gameurlweb" name='gameurlweb' placeholder="http://game-url" value="{{user_entry_url_web}}">
+				</span>
+			</div>
+			<div class="form-group">
+				<span style="{{#user_has_url_windows}}display: none; {{/user_has_url_windows}}">
+					<a href='#' onclick='ToggleURLEntry($(this));'>Add Windows build</a>
+				</span>
+				<span style="{{^user_has_url_windows}}display: none; {{/user_has_url_windows}}">
+					<label for="gameurlwin">URL to Windows build</label>
+					<input type="url" class="form-control" id="gameurlwin" name='gameurlwin' placeholder="http://game-url" value="{{user_entry_url_windows}}">
+				</span>
+			</div>
+			<div class="form-group">
+				<span style="{{#user_has_url_mac}}display: none; {{/user_has_url_mac}}">
+					<a href='#' onclick='ToggleURLEntry($(this));'>Add Mac build</a>
+				</span>
+				<span style="{{^user_has_url_mac}}display: none; {{/user_has_url_mac}}">
+					<label for="gameurlmac">URL to Mac build</label>
+					<input type="url" class="form-control" id="gameurlmac" name='gameurlmac' placeholder="http://game-url" value="{{user_entry_url_mac}}">
+				</span>
+			</div>
+			<div class="form-group">
+				<span style="{{#user_has_url_linux}}display: none; {{/user_has_url_linux}}">
+					<a href='#' onclick='ToggleURLEntry($(this));'>Add Linux build</a>
+				</span>
+				<span style="{{^user_has_url_linux}}display: none; {{/user_has_url_linux}}">
+					<label for="gameurllinux">URL to Linux build</label>
+					<input type="url" class="form-control" id="gameurllinux" name='gameurllinux' placeholder="http://game-url" value="{{user_entry_url_linux}}">
+				</span>
+			</div>
+			<div class="form-group">
+				<span style="{{#user_has_url_ios}}display: none; {{/user_has_url_ios}}">
+					<a href='#' onclick='ToggleURLEntry($(this));'>Add iOS build</a>
+				</span>
+				<span style="{{^user_has_url_ios}}display: none; {{/user_has_url_ios}}">
+					<label for="gameurlios">URL to iOS build</label>
+					<input type="url" class="form-control" id="gameurlios" name='gameurlios' placeholder="http://game-url" value="{{user_entry_url_ios}}">
+				</span>
+			</div>
+			<div class="form-group">
+				<span style="{{#user_has_url_android}}display: none; {{/user_has_url_android}}">
+					<a href='#' onclick='ToggleURLEntry($(this));'>Add Android build</a>
+				</span>
+				<span style="{{^user_has_url_android}}display: none; {{/user_has_url_android}}">
+					<label for="gameurlandroid">URL to Android build</label>
+					<input type="url" class="form-control" id="gameurlandroid" name='gameurlandroid' placeholder="http://game-url" value="{{user_entry_url_android}}">
+				</span>
+			</div>
+			<div class="form-group">
+				<span style="{{#user_has_url}}display: none; {{/user_has_url}}">
+					<a href='#' onclick='ToggleURLEntry($(this));'>Add build for another platform</a>
+				</span>
+				<span style="{{^user_has_url}}display: none; {{/user_has_url}}">
+					<label for="gameurl">URL to build for another platform</label>
+					<input type="url" class="form-control" id="gameurl" name='gameurl' placeholder="http://game-url" value="{{user_entry_url}}">
+				</span>
+			</div>
+			<div class="form-group">
+				<label for="screenshotfile">Screenshot (Change)</label>
+				<input type="file" class="form-control" id="screenshotfile" name='screenshotfile' placeholder="Screenshot file" value="{{user_entry_screenshot}}">
+			</div>
+			<div class="form-group">
+				<label for="description">Brief game description</label>
+				<textarea class="form-control" id="description" name='description' placeholder="Game description">{{user_entry_desc}}</textarea>
+			</div>
+
+			<input type="hidden" name="jam_number" value="{{submit_jam.jam_number}}" />
+			<button type="submit" name='action' value='submit' class="btn btn-default">Submit</button>
+		</form>
+	</div>
+
 	{{{#user_entry_name}}}
 		<p>
 			<h3>Share</h3>


### PR DESCRIPTION
* **"Edit entry" buttons are edded to the profile page** to let users tweak previous entries. Those buttons are of course only visible when viewing your own page (even for admins - feel free to change that!)
* This UI choice means you can't submit new games to previous jams. I also added server-side checks to enforce that, preventing HTML/URL hacks :P
* The submit page now has a header to let you know which jam you're submitting to

![screen1](https://cloud.githubusercontent.com/assets/694508/21587819/c2eb7a10-d0e0-11e6-8099-89f6049a2c96.PNG)
![screen2](https://cloud.githubusercontent.com/assets/694508/21587820/c2fc7518-d0e0-11e6-8a32-cedbb0bc5715.PNG)
