### PR TITLE
Fix config.txt initialization on a fresh install

### DIFF
--- a/php/config.php
+++ b/php/config.php
@@ -423,17 +423,6 @@ function LoadConfig(){
 				break;
 			}
 			
-			$i = count($dictionary["CONFIG"]);
-			foreach($dictionary["CONFIG"] as $index => $configDictionaryEntry){
-				if($configDictionaryEntry["CATEGORY_ID"] == $configCategoryID){
-					$i = $index;
-				}
-			}
-			
-			$dictionary["CONFIG"][$i]["CATEGORY_ID"] = $configCategoryID;
-			$dictionary["CONFIG"][$i]["CATEGORY_HEADER"] = $configCategoryHeader;
-			$dictionary["CONFIG"][$i]["ENTRIES"][] = $configEntry;
-			
 			//Validate line
 			switch($key){
 				case "PEPPER":
@@ -458,6 +447,17 @@ function LoadConfig(){
 					$linesUpdated[] = $line;
 				break;
 			}
+			
+			$i = count($dictionary["CONFIG"]);
+			foreach($dictionary["CONFIG"] as $index => $configDictionaryEntry){
+				if($configDictionaryEntry["CATEGORY_ID"] == $configCategoryID){
+					$i = $index;
+				}
+			}
+			
+			$dictionary["CONFIG"][$i]["CATEGORY_ID"] = $configCategoryID;
+			$dictionary["CONFIG"][$i]["CATEGORY_HEADER"] = $configCategoryHeader;
+			$dictionary["CONFIG"][$i]["ENTRIES"][] = $configEntry;
 		}
 	}
 }


### PR DESCRIPTION
When doing a fresh install, the `PEPPER` & `SESSION_PASSWORD_ITERATIONS` keys kept being generated and written to the top of the file at each page load.

I'm not 100% sure how config categories work, but I've checked that the config administration page still works after the fix.