### PR TITLE
Add default asset max size and format asset max sizes

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,8 @@ This will setup a scotchbox vagrant box with 1hgj fully installed. You only need
 ## Manually:
 What you need is a web server capable of running PHP, for example Apache.
 
+If you prefer to follow a video tutorial, [click here](https://www.youtube.com/watch?v=NiaaSXDoVf0).
+
 ### 1: Download XAMPP
 
 * Go to [Apache](https://www.apachefriends.org/download.html) and download a version for your operating system (For PHP 5.6, not a VM version)

--- a/SQL/1hgj.sql
+++ b/SQL/1hgj.sql
@@ -623,8 +623,8 @@ VALUES
 (null,Now(),'-1','MAX_COLORS_FOR_JAM', '16', 'NEW_JAM_DEFAULTS', 'Maximum number of colors that will be available for each jam', 'NUMBER', '[]', '1', '1', '1'),
 (null,Now(),'-1','MINIMUM_DISPLAY_NAME_LENGTH', '1', 'USERS', 'Shortest user display name', 'NUMBER', '[]', '1', '1', '1'),
 (null,Now(),'-1','MAXIMUM_DISPLAY_NAME_LENGTH', '50', 'USERS', 'Longest user display name', 'NUMBER', '[]', '1', '1', '1'),
-(null,Now(),'-1','MAX_SCREENSHOT_FILE_SIZE_IN_BYTES', '5000000', 'JAM_SETTINGS', 'Maximum screenshot file size in bytes', 'NUMBER', '[]', '0', '1', '1'),
-(null,Now(),'-1','MAX_ASSET_FILE_SIZE_IN_BYTES', '5000000', 'ASSETS', 'Maximum asset file size in bytes', 'NUMBER', '[]', '0', '1', '1'),
+(null,Now(),'-1','MAX_SCREENSHOT_FILE_SIZE_IN_BYTES', '5242880', 'JAM_SETTINGS', 'Maximum screenshot file size in bytes', 'NUMBER', '[]', '0', '1', '1'),
+(null,Now(),'-1','MAX_ASSET_FILE_SIZE_IN_BYTES', '15728640', 'ASSETS', 'Maximum asset file size in bytes', 'NUMBER', '[]', '0', '1', '1'),
 (null,Now(),'-1','JAM_AUTO_SCHEDULER_MINUTES_BEFORE_JAM', '120', 'JAM_SETTINGS', 'How many minutes before the next jam should the jam autoscheduler schedule a jam?', 'NUMBER', '[]', '1', '1', '1'),
 (null,Now(),'-1','JAM_AUTO_SCHEDULER_ENABLED', '0', 'JAM_SETTINGS', 'Should the jam autoscheduler automatically schedule jams?', 'ENUM', '[{\"VALUE\":0,\"TEXT\":\"No\"},{\"VALUE\":1,\"TEXT\":\"Yes\"}]', '1', '1', '1'),
 (null,Now(),'-1','DATABASE_VERSION', '1', 'SYSTEM', 'The version of the database. Used to determine required database migration.', 'NUMBER', '[]', '0', '1', '1');

--- a/SQL/1hgj.sql
+++ b/SQL/1hgj.sql
@@ -624,6 +624,7 @@ VALUES
 (null,Now(),'-1','MINIMUM_DISPLAY_NAME_LENGTH', '1', 'USERS', 'Shortest user display name', 'NUMBER', '[]', '1', '1', '1'),
 (null,Now(),'-1','MAXIMUM_DISPLAY_NAME_LENGTH', '50', 'USERS', 'Longest user display name', 'NUMBER', '[]', '1', '1', '1'),
 (null,Now(),'-1','MAX_SCREENSHOT_FILE_SIZE_IN_BYTES', '5000000', 'JAM_SETTINGS', 'Maximum screenshot file size in bytes', 'NUMBER', '[]', '0', '1', '1'),
+(null,Now(),'-1','MAX_ASSET_FILE_SIZE_IN_BYTES', '5000000', 'ASSETS', 'Maximum asset file size in bytes', 'NUMBER', '[]', '0', '1', '1'),
 (null,Now(),'-1','JAM_AUTO_SCHEDULER_MINUTES_BEFORE_JAM', '120', 'JAM_SETTINGS', 'How many minutes before the next jam should the jam autoscheduler schedule a jam?', 'NUMBER', '[]', '1', '1', '1'),
 (null,Now(),'-1','JAM_AUTO_SCHEDULER_ENABLED', '0', 'JAM_SETTINGS', 'Should the jam autoscheduler automatically schedule jams?', 'ENUM', '[{\"VALUE\":0,\"TEXT\":\"No\"},{\"VALUE\":1,\"TEXT\":\"Yes\"}]', '1', '1', '1'),
 (null,Now(),'-1','DATABASE_VERSION', '1', 'SYSTEM', 'The version of the database. Used to determine required database migration.', 'NUMBER', '[]', '0', '1', '1');

--- a/index.php
+++ b/index.php
@@ -645,7 +645,6 @@ if($page == "jam")
 								die('Cannot make a new submission to a past jam');
 							}
 
-							// Get the maximum size of the entry screenshot
 							$dictionary["user_entry_screenshot_max_size"] = bytesToString($config["MAX_SCREENSHOT_FILE_SIZE_IN_BYTES"]["VALUE"]);
 
 							print $mustache->render(file_get_contents($templateBasePath."submit.html"), $dictionary);
@@ -667,7 +666,6 @@ if($page == "jam")
 							}
 						break;
 						case "editasset":
-							// Get the maximum size of the entry screenshot
 							$dictionary["asset_max_size"] = bytesToString($config["MAX_ASSET_FILE_SIZE_IN_BYTES"]["VALUE"]);
 							if(IsAdmin()){
 								print $mustache->render(file_get_contents($templateBasePath."editasset.html"), $dictionary);

--- a/index.php
+++ b/index.php
@@ -667,6 +667,8 @@ if($page == "jam")
 							}
 						break;
 						case "editasset":
+							// Get the maximum size of the entry screenshot
+							$dictionary["asset_max_size"] = bytesToString($config["MAX_ASSET_FILE_SIZE_IN_BYTES"]["VALUE"]);
 							if(IsAdmin()){
 								print $mustache->render(file_get_contents($templateBasePath."editasset.html"), $dictionary);
 							}

--- a/template/editasset.html
+++ b/template/editasset.html
@@ -31,7 +31,7 @@
 			</div>
 			<div class="form-group">
 				<label for="assetfile">Asset File (Change)</label>
-				<br />(up to {{CONFIG.VALUES.MAX_ASSET_FILE_SIZE_IN_BYTES}} Bytes)
+				<br />(up to {{asset_max_size}})
 				<input type="file" class="form-control" id="assetfile" name='assetfile' placeholder="Asset file" value="{{editingasset.content}}">
 			</div>
 


### PR DESCRIPTION
The default config sql now has an asset size field.

Assets now have a maximum bytes readout with correct units.