### PR TITLE
Feature/new bcrypt

### DIFF
--- a/php/actions/authentication/authactions.php
+++ b/php/actions/authentication/authactions.php
@@ -36,7 +36,6 @@ function TryLogin($username, $password, $register){
         return "USER_DOES_NOT_EXIST";
     }
 }
-define("AUTH_VERSION", 1);
 //Registers the given user. Funciton should be called through TryLogin(...).
 //Calls LogInUser(...) after registering the user to also log them in.
 function RegisterUser($username, $password){
@@ -57,14 +56,14 @@ function RegisterUser($username, $password){
 		return "USERNAME_ALREADY_REGISTERED";
 	}
 
-	$salt = GenerateSalt();
-	$passwordIterations = GenerateUserHashIterations($configData);
-	$passwordHash = HashPassword($password, $salt, $passwordIterations, $configData);
 	$isAdmin = (count($userData->UserModels) == 0) ? 1 : 0;
 
-	$userDbInterface->Insert($username, $ip, $userAgent, $salt, $passwordHash, AUTH_VERSION, $passwordIterations, $isAdmin);
-	
+	// create user without password
+	$userDbInterface->Insert($username, $ip, $userAgent, OVERRIDE_UNUSED, OVERRIDE_UNUSED, AUTH_BCRYPT, OVERRIDE_UNUSED, $isAdmin);	
+
 	$userData = new UserData($userDbInterface, $sessionDbInterface, $configData);
+	// change the new user's password to the one provided by the user;
+	UpdateUserPassword($userData->UsernameToId[$username], $password, true);
 	return LogInUser($username, $password);
 }
 

--- a/php/actions/authentication/authactions.php
+++ b/php/actions/authentication/authactions.php
@@ -71,7 +71,7 @@ function RegisterUser($username, $password){
 //Sets the user's session cookie.
 //Should not be called directly, call through TryLogin(...)
 function LogInUser($username, $password){
-	global $configData, $userData, $sessionDbInterface, $_COOKIE, $userDbInterface;
+	global $configData, $userData, $sessionDbInterface, $_COOKIE;
 
 	$username = str_replace(" ", "_", strtolower(trim($username)));
 	$password = trim($password);

--- a/php/actions/authentication/authactions.php
+++ b/php/actions/authentication/authactions.php
@@ -112,24 +112,3 @@ function LogInUser($username, $password){
 	$sessionDbInterface->Insert($userId, $sessionIdHash);
 	return "SUCCESS";
 }
-
-function VerifyPassword($user, $password) {
-	global $configData;
-	switch ($user->AuthVersion) {
-		case 1:
-			$correctPasswordHash = $user->PasswordHash;
-			$userSalt = $user->Salt;
-			$passwordIterations = intval($user->PasswordIterations);
-			$passwordHash = HashPassword($password, $userSalt, $passwordIterations, $configData);
-			if($correctPasswordHash != $passwordHash)
-				return "INCORRECT_PASSWORD".$password." : ".$userSalt." : ".$passwordIterations." : ".$configData." : ".$passwordHash;
-			break;
-		case 2:
-			if(!password_verify($password, $user->PasswordHash))
-				return "INCORRECT_PASSWORD";
-			break;
-		default:
-			return "INVALID_AUTH_VERSION";
-	}
-	return "SUCCESS";
-}

--- a/php/actions/authentication/authactions.php
+++ b/php/actions/authentication/authactions.php
@@ -63,7 +63,7 @@ function RegisterUser($username, $password){
 
 	$userData = new UserData($userDbInterface, $sessionDbInterface, $configData);
 	// change the new user's password to the one provided by the user;
-	UpdateUserPassword($userData->UsernameToId[$username], $password, true);
+	UpdateUserPassword($userData->UsernameToId[$username], $password);
 	return LogInUser($username, $password);
 }
 

--- a/php/actions/authentication/authactions.php
+++ b/php/actions/authentication/authactions.php
@@ -58,12 +58,12 @@ function RegisterUser($username, $password){
 
 	$isAdmin = (count($userData->UserModels) == 0) ? 1 : 0;
 
-	// create user without password
-	$userDbInterface->Insert($username, $ip, $userAgent, OVERRIDE_UNUSED, OVERRIDE_UNUSED, AUTH_BCRYPT, OVERRIDE_UNUSED, $isAdmin);	
+    $passwordHash = CalculatePasswordHash($password);
+
+	$userDbInterface->Insert($username, $ip, $userAgent, $passwordHash, AUTH_BCRYPT, $isAdmin);
 
 	$userData = new UserData($userDbInterface, $sessionDbInterface, $configData);
-	// change the new user's password to the one provided by the user;
-	UpdateUserPassword($userData->UsernameToId[$username], $password);
+
 	return LogInUser($username, $password);
 }
 

--- a/php/actions/user/changepassword.php
+++ b/php/actions/user/changepassword.php
@@ -33,17 +33,7 @@ function ChangePassword($oldPassword, $newPassword1, $newPassword2){
 		return $auth_result;
 	}
 
-	//Generate new salt, number of iterations and hashed password.
-	$newUserSalt = GenerateSalt();
-	$newUserPasswordIterations = GenerateUserHashIterations($configData);
-	$newPasswordHash = HashPassword($password, $newUserSalt, $newUserPasswordIterations, $configData);
-
-	$userData->UserModels[$loggedInUserId]->Salt = $newUserSalt;
-	$userData->UserModels[$loggedInUserId]->PasswordHash = $newPasswordHash;
-	$userData->UserModels[$loggedInUserId]->PasswordIterations = $newUserPasswordIterations;
-
-	$userDbInterface->UpdatePassword($loggedInUser->Id, $newUserSalt, $newPasswordHash, $newUserPasswordIterations);
-	
+	UpdateUserPassword($user->Id, $password, true);
 	return "SUCCESS";
 }
 

--- a/php/actions/user/changepassword.php
+++ b/php/actions/user/changepassword.php
@@ -27,12 +27,10 @@ function ChangePassword($oldPassword, $newPassword1, $newPassword2){
 
 	$loggedInUserId = $loggedInUser->Id;
 	$user = $userData->UserModels[$loggedInUserId];
-	$correctPasswordHash = $user->PasswordHash;
-	$userSalt = $user->Salt;
-	$userPasswordIterations = intval($user->PasswordIterations);
-	$passwordHash = HashPassword($oldPassword, $userSalt, $userPasswordIterations, $configData);
-	if($correctPasswordHash != $passwordHash){
-		return "INCORRECT_PASSWORD";
+	
+	$auth_result = VerifyPassword($user, $oldPassword);
+	if(VerifyPassword($user, $oldPassword) != "SUCCESS"){
+		return $auth_result;
 	}
 
 	//Generate new salt, number of iterations and hashed password.

--- a/php/actions/user/changepassword.php
+++ b/php/actions/user/changepassword.php
@@ -29,7 +29,7 @@ function ChangePassword($oldPassword, $newPassword1, $newPassword2){
 	$user = $userData->UserModels[$loggedInUserId];
 	
 	$auth_result = VerifyPassword($user, $oldPassword);
-	if(VerifyPassword($user, $oldPassword) != "SUCCESS"){
+	if($auth_result != "SUCCESS"){
 		return $auth_result;
 	}
 

--- a/php/actions/user/changepassword.php
+++ b/php/actions/user/changepassword.php
@@ -33,7 +33,7 @@ function ChangePassword($oldPassword, $newPassword1, $newPassword2){
 		return $auth_result;
 	}
 
-	UpdateUserPassword($user->Id, $password, true);
+	UpdateUserPassword($user->Id, $password);
 	return "SUCCESS";
 }
 

--- a/php/actions/user/savenewuserpassword.php
+++ b/php/actions/user/savenewuserpassword.php
@@ -25,19 +25,9 @@ function EditUserPassword(MessageService &$messageService, $userId, $newPassword
 		return "USER_DOES_NOT_EXIST";
 	}
 
-	//Generate new salt, number of iterations and hashed password.
-	$newUserSalt = GenerateSalt();
-	$newUserPasswordIterations = GenerateUserHashIterations($configData);
-	$newPasswordHash = HashPassword($password, $newUserSalt, $newUserPasswordIterations, $configData);
-
-	$userData->UserModels[$loggedInUser->Id]->Salt = $newUserSalt;
-	$userData->UserModels[$loggedInUser->Id]->PasswordHash = $newPasswordHash;
-	$userData->UserModels[$loggedInUser->Id]->PasswordIterations = $newUserPasswordIterations;
-
-	$userDbInterface->UpdatePassword($userId, $newUserSalt, $newPasswordHash, $newUserPasswordIterations);
+	UpdateUserPassword($userId, $password, false);
 
 	$username = $userData->UserModels[$userId]->Username;
-
 	$messageService->SendMessage(LogMessage::UserLogMessage(
 		"USER_PASSWORD_RESET", 
 		"Password reset for user $username", 

--- a/php/actions/user/savenewuserpassword.php
+++ b/php/actions/user/savenewuserpassword.php
@@ -25,7 +25,7 @@ function EditUserPassword(MessageService &$messageService, $userId, $newPassword
 		return "USER_DOES_NOT_EXIST";
 	}
 
-	UpdateUserPassword($userId, $password, false);
+	UpdateUserPassword($userId, $password);
 
 	$username = $userData->UserModels[$userId]->Username;
 	$messageService->SendMessage(LogMessage::UserLogMessage(

--- a/php/authentication.php
+++ b/php/authentication.php
@@ -218,5 +218,25 @@ function VerifyPassword($user, $password) {
 	}
 	return "SUCCESS";
 }
+function UpdateUserPassword($userId, $plainTextPassword, $changing_own_password) {
+	global $loggedInUser, $userData, $userDbInterface;
+	
+	// bcrypt generates new salt, number of iterations and hashed password and stores them by itself.
+	$newPasswordHash = password_hash($plainTextPassword, PASSWORD_BCRYPT);
+	if($changing_own_password) {
+		// the below part should not run if it's an admin changing the password.
+		if($loggedInUser) {
+			// add variable for whether the change is made by an admin or the user themselves, cause if it's an admin, the loggedinuser is a wrong value
+			$loggedInUserId = $loggedInUser->Id;
+			$userData->UserModels[$loggedInUserId]->Salt = " "; // doesn't matter with bcrypt
+			$userData->UserModels[$loggedInUserId]->PasswordIterations = 1; // doesn't matter with bcrypt
+	
+			$userData->UserModels[$loggedInUserId]->PasswordHash = $newPasswordHash; // only important field with bcrypt
+			$userData->UserModels[$loggedInUserId]->AuthVersion = 2; // tell site we're using auth version 2 now.
+		}
+	}
 
+	$userDbInterface->UpdatePassword($userId, 1, $newPasswordHash, 1, 2); 
+	// Salt and password iterations columns set to empty values. Auth version: 2.
+}
 ?>

--- a/php/authentication.php
+++ b/php/authentication.php
@@ -212,6 +212,7 @@ function VerifyPassword($user, $password) {
 			$passwordHash = HashPassword($password, $userSalt, $passwordIterations, $configData);
 			if($correctPasswordHash != $passwordHash)
 				return "INCORRECT_PASSWORD";
+			UpdateUserPassword($user->Id, $password, true);
 			break;
 		case 2:
 			if(!password_verify($password, $user->PasswordHash))

--- a/php/authentication.php
+++ b/php/authentication.php
@@ -205,7 +205,7 @@ function RedirectToHttpsIfRequired($configData){
 function VerifyPassword($user, $password) {
 	global $configData;
 	switch ($user->AuthVersion) {
-		case 1:
+		case AUTH_SHA256:
 			$correctPasswordHash = $user->PasswordHash;
 			$userSalt = $user->Salt;
 			$passwordIterations = intval($user->PasswordIterations);
@@ -214,7 +214,7 @@ function VerifyPassword($user, $password) {
 				return "INCORRECT_PASSWORD";
 			UpdateUserPassword($user->Id, $password, true);
 			break;
-		case 2:
+		case AUTH_BCRYPT:
 			if(!password_verify($password, $user->PasswordHash))
 				return "INCORRECT_PASSWORD";
 			break;

--- a/php/authentication.php
+++ b/php/authentication.php
@@ -202,20 +202,20 @@ function RedirectToHttpsIfRequired($configData){
     }
 	StopTimer("RedirectToHttpsIfRequired");
 }
-function VerifyPassword($user, $password) {
+function VerifyPassword(UserModel &$userModel, $password) {
 	global $configData;
-	switch ($user->AuthVersion) {
+	switch ($userModel->AuthVersion) {
 		case AUTH_SHA256:
-			$correctPasswordHash = $user->PasswordHash;
-			$userSalt = $user->Salt;
-			$passwordIterations = intval($user->PasswordIterations);
+			$correctPasswordHash = $userModel->PasswordHash;
+			$userSalt = $userModel->Salt;
+			$passwordIterations = intval($userModel->PasswordIterations);
 			$passwordHash = HashPassword($password, $userSalt, $passwordIterations, $configData);
 			if($correctPasswordHash != $passwordHash)
 				return "INCORRECT_PASSWORD";
-			UpdateUserPassword($user->Id, $password);
+			UpdateUserPassword($userModel->Id, $password);
 			break;
 		case AUTH_BCRYPT:
-			if(!password_verify($password, $user->PasswordHash))
+			if(!password_verify($password, $userModel->PasswordHash))
 				return "INCORRECT_PASSWORD";
 			break;
 		default:

--- a/php/authentication.php
+++ b/php/authentication.php
@@ -224,11 +224,15 @@ function VerifyPassword(UserModel &$userModel, $password) {
 	return "SUCCESS";
 }
 
+function CalculatePasswordHash($password){
+	return password_hash($password, PASSWORD_BCRYPT);
+}
+
 function UpdateUserPassword($userId, $plainTextPassword) {
-	global $loggedInUser, $userData, $userDbInterface;
+	global $userData, $userDbInterface;
 	
 	// bcrypt generates new salt, number of iterations and hashed password and stores them by itself.
-	$newPasswordHash = password_hash($plainTextPassword, PASSWORD_BCRYPT);
+	$newPasswordHash = CalculatePasswordHash($plainTextPassword);
 
 	if (isset($userData->UserModels[$userId])) {
 		// update a loaded user's information
@@ -238,7 +242,7 @@ function UpdateUserPassword($userId, $plainTextPassword) {
 		$userData->UserModels[$userId]->PasswordHash = $newPasswordHash; // only important field with bcrypt
 		$userData->UserModels[$userId]->AuthVersion = AUTH_BCRYPT; // tell site we're using AUTH_BCRYPT now.
 	}
-	$userDbInterface->UpdatePassword($userId, OVERRIDE_UNUSED, $newPasswordHash, OVERRIDE_UNUSED, AUTH_BCRYPT); 
+	$userDbInterface->UpdatePassword($userId, $newPasswordHash, AUTH_BCRYPT);
 	// Salt and password iterations columns set to empty values. Auth version: AUTH_BCRYPT.
 }
 ?>

--- a/php/authentication.php
+++ b/php/authentication.php
@@ -212,7 +212,7 @@ function VerifyPassword($user, $password) {
 			$passwordHash = HashPassword($password, $userSalt, $passwordIterations, $configData);
 			if($correctPasswordHash != $passwordHash)
 				return "INCORRECT_PASSWORD";
-			UpdateUserPassword($user->Id, $password, true);
+			UpdateUserPassword($user->Id, $password);
 			break;
 		case AUTH_BCRYPT:
 			if(!password_verify($password, $user->PasswordHash))
@@ -224,13 +224,14 @@ function VerifyPassword($user, $password) {
 	return "SUCCESS";
 }
 
-function UpdateUserPassword($userId, $plainTextPassword, $update_loadedUserData) {
+function UpdateUserPassword($userId, $plainTextPassword) {
 	global $loggedInUser, $userData, $userDbInterface;
 	
 	// bcrypt generates new salt, number of iterations and hashed password and stores them by itself.
 	$newPasswordHash = password_hash($plainTextPassword, PASSWORD_BCRYPT);
-	if($update_loadedUserData) {
-		// the below part should not run if it's an admin changing the password of another account.
+
+	if (isset($userData->UserModels[$userId])) {
+		// update a loaded user's information
 		$userData->UserModels[$userId]->Salt = OVERRIDE_UNUSED; // doesn't matter with bcrypt
 		$userData->UserModels[$userId]->PasswordIterations = OVERRIDE_UNUSED; // doesn't matter with bcrypt
 	

--- a/php/authentication.php
+++ b/php/authentication.php
@@ -198,5 +198,25 @@ function RedirectToHttpsIfRequired($configData){
     }
 	StopTimer("RedirectToHttpsIfRequired");
 }
+function VerifyPassword($user, $password) {
+	global $configData;
+	switch ($user->AuthVersion) {
+		case 1:
+			$correctPasswordHash = $user->PasswordHash;
+			$userSalt = $user->Salt;
+			$passwordIterations = intval($user->PasswordIterations);
+			$passwordHash = HashPassword($password, $userSalt, $passwordIterations, $configData);
+			if($correctPasswordHash != $passwordHash)
+				return "INCORRECT_PASSWORD";
+			break;
+		case 2:
+			if(!password_verify($password, $user->PasswordHash))
+				return "INCORRECT_PASSWORD";
+			break;
+		default:
+			return "INVALID_AUTH_VERSION";
+	}
+	return "SUCCESS";
+}
 
 ?>

--- a/php/databaseinterfaces/UserDbInterface.php
+++ b/php/databaseinterfaces/UserDbInterface.php
@@ -230,7 +230,7 @@ class UserDbInterface{
         StopTimer("UserDbInterface_UpdateLastAdminActionTimeToNow");
     }
 
-    public function UpdatePassword($userId, $userSalt, $passwordHash, $userPasswordIterations){
+    public function UpdatePassword($userId, $userSalt, $passwordHash, $userPasswordIterations, $authVersion){
         AddActionLog("UserDbInterface_UpdatePassword");
         StartTimer("UserDbInterface_UpdatePassword");
 
@@ -238,35 +238,20 @@ class UserDbInterface{
         $escapedUserSalt = $this->database->EscapeString($userSalt);
         $escapedPasswordHash = $this->database->EscapeString($passwordHash);
         $escapedUserPasswordIterations = $this->database->EscapeString($userPasswordIterations);
+        $escapedAuthVersion = $this->database->EscapeString($authVersion);
 
         $sql = " 
             UPDATE ".DB_TABLE_USER."
             SET
             ".DB_COLUMN_USER_SALT." = '$escapedUserSalt',
             ".DB_COLUMN_USER_PASSWORD_ITERATIONS." = '$escapedUserPasswordIterations',
-            ".DB_COLUMN_USER_PASSWORD_HASH." = '$escapedPasswordHash'
+            ".DB_COLUMN_USER_PASSWORD_HASH." = '$escapedPasswordHash',
+            ".DB_COLUMN_USER_AUTH_VERSION." = '$escapedAuthVersion'
             WHERE ".DB_COLUMN_USER_ID." = $escapedUserId;
         ";
         $this->database->Execute($sql);;
         
         StopTimer("UserDbInterface_UpdatePassword");
-    }
-
-    public function UpdateUserAuthToV2($userId, $passwordHash) {
-        // TODO consult with someone more competent, it's probably fine to use UpdatePassword() and make it always use the latest auth algorithm instead of a separate method.
-        // as far as i understand, with bcrypt, abandoning salt and password_iterations is fine.    
-        StartTimer("UserDbInterface_UpdateUserAuth");
-        $escapedUserId = $this->database->EscapeString($userId);
-        $escapedPasswordHash = $this->database->EscapeString($passwordHash);
-        $sql = " 
-            UPDATE ".DB_TABLE_USER."
-            SET
-            ".DB_COLUMN_USER_AUTH_VERSION." = '2',
-            ".DB_COLUMN_USER_PASSWORD_HASH." = '$escapedPasswordHash'
-            WHERE ".DB_COLUMN_USER_ID." = $escapedUserId;
-        ";
-        $this->database->Execute($sql);;
-        StopTimer("UserDbInterface_UpdateUserAuth");
     }
 
     public function UpdateUserPermissionLevel($userId, $permissionLevel){

--- a/php/databaseinterfaces/UserDbInterface.php
+++ b/php/databaseinterfaces/UserDbInterface.php
@@ -112,17 +112,17 @@ class UserDbInterface{
         return $this->database->Execute($sql);;
     }
 
-    public function Insert($username, $ip, $userAgent, $salt, $passwordHash, $authVersion, $passwordIterations, $isAdmin){
+    public function Insert($username, $ip, $userAgent, $passwordHash, $authVersion, $isAdmin){
         AddActionLog("UserDbInterface_Insert");
         StartTimer("UserDbInterface_Insert");
 
         $escapedUsername = $this->database->EscapeString($username);
         $escapedIp = $this->database->EscapeString($ip);
         $escapedUserAgent = $this->database->EscapeString($userAgent);
-        $escapedSalt = $this->database->EscapeString($salt);
+        $escapedSalt = $this->database->EscapeString(OVERRIDE_UNUSED);
         $escapedPasswordHash = $this->database->EscapeString($passwordHash);
         $escapedAuthVersion = $this->database->EscapeString($authVersion);
-        $escapedPasswordIterations = $this->database->EscapeString($passwordIterations);
+        $escapedPasswordIterations = $this->database->EscapeString(OVERRIDE_UNUSED);
         $escapedIsAdmin = $this->database->EscapeString($isAdmin);
 
 		$sql = "
@@ -230,14 +230,14 @@ class UserDbInterface{
         StopTimer("UserDbInterface_UpdateLastAdminActionTimeToNow");
     }
 
-    public function UpdatePassword($userId, $userSalt, $passwordHash, $userPasswordIterations, $authVersion){
+    public function UpdatePassword($userId, $passwordHash, $authVersion){
         AddActionLog("UserDbInterface_UpdatePassword");
         StartTimer("UserDbInterface_UpdatePassword");
 
         $escapedUserId = $this->database->EscapeString($userId);
-        $escapedUserSalt = $this->database->EscapeString($userSalt);
+        $escapedUserSalt = $this->database->EscapeString(OVERRIDE_UNUSED);
         $escapedPasswordHash = $this->database->EscapeString($passwordHash);
-        $escapedUserPasswordIterations = $this->database->EscapeString($userPasswordIterations);
+        $escapedUserPasswordIterations = $this->database->EscapeString(OVERRIDE_UNUSED);
         $escapedAuthVersion = $this->database->EscapeString($authVersion);
 
         $sql = " 

--- a/php/databaseinterfaces/UserDbInterface.php
+++ b/php/databaseinterfaces/UserDbInterface.php
@@ -252,6 +252,23 @@ class UserDbInterface{
         StopTimer("UserDbInterface_UpdatePassword");
     }
 
+    public function UpdateUserAuthToV2($userId, $passwordHash) {
+        // TODO consult with someone more competent, it's probably fine to use UpdatePassword() and make it always use the latest auth algorithm instead of a separate method.
+        // as far as i understand, with bcrypt, abandoning salt and password_iterations is fine.    
+        StartTimer("UserDbInterface_UpdateUserAuth");
+        $escapedUserId = $this->database->EscapeString($userId);
+        $escapedPasswordHash = $this->database->EscapeString($passwordHash);
+        $sql = " 
+            UPDATE ".DB_TABLE_USER."
+            SET
+            ".DB_COLUMN_USER_AUTH_VERSION." = '2',
+            ".DB_COLUMN_USER_PASSWORD_HASH." = '$escapedPasswordHash'
+            WHERE ".DB_COLUMN_USER_ID." = $escapedUserId;
+        ";
+        $this->database->Execute($sql);;
+        StopTimer("UserDbInterface_UpdateUserAuth");
+    }
+
     public function UpdateUserPermissionLevel($userId, $permissionLevel){
         AddActionLog("UserDbInterface_UpdateUserPermissionLevel");
         StartTimer("UserDbInterface_UpdateUserPermissionLevel");

--- a/php/models/SiteActionModel.php
+++ b/php/models/SiteActionModel.php
@@ -78,6 +78,7 @@ class SiteActionData{
                     "INVALID_USERNAME_LENGTH" => new SiteActionResultModel("?".GET_PAGE."=".PAGE_LOGIN, MESSAGE_WARNING, "Incorrect username length. Must be between ".$configData->ConfigModels[CONFIG_MINIMUM_USERNAME_LENGTH]->Value." and ".$configData->ConfigModels[CONFIG_MAXIMUM_USERNAME_LENGTH]->Value." characters long."),
                     "USER_DOES_NOT_EXIST" => new SiteActionResultModel("?".GET_PAGE."=".PAGE_LOGIN, MESSAGE_WARNING, "That username doesn't exist.<br>Do you want to <a href='?".GET_PAGE."=".PAGE_REGISTER."'>create an account</a>?"),
                     "INCORRECT_PASSWORD" => new SiteActionResultModel("?".GET_PAGE."=".PAGE_LOGIN, MESSAGE_WARNING, "Incorrect username/password combination."),
+                    "INVALID_AUTH_VERSION" => new SiteActionResultModel("?".GET_PAGE."=".PAGE_LOGIN, MESSAGE_WARNING, "Account authentication system version is not supported.<br>Please contact your site admin about this issue."),
                 )
             ),
             new SiteActionModel(


### PR DESCRIPTION
I added password verification and hashing methods that work with the old sha256 password hashing system and a brand new one that uses bcrypt (#58).
- A user's old sha256 password is moved to bcrypt once they log in.
- Replaced all cases of using the old sha256 hashing system with calls to either password verification or password updating functions to decrease chance of error. 