### PR TITLE
Fix 213: Moves privacy and user data to user dropdown and register page

### DIFF
--- a/template/header.mustache
+++ b/template/header.mustache
@@ -114,8 +114,10 @@
 									<ul class="dropdown-menu">
 										<li><a href='?{{{forms.get.page}}}={{{forms.pages.author}}}&{{{forms.get.author.username}}}={{user.username}}'>Profile</a></li>
 										{{^cookies.is_streamer}}
-											<li><a href='?{{{forms.get.page}}}={{{forms.pages.usersettings}}}'>User settings</a></li>
+                                            <li><a href='?{{{forms.get.page}}}={{{forms.pages.usersettings}}}'>User settings</a></li>
+                                            <li><a href='?{{{forms.get.page}}}={{{forms.pages.userdata}}}'>Your data</a></li>
 										{{/cookies.is_streamer}}
+                                        <li><a href='?{{{forms.get.page}}}={{{forms.pages.privacy}}}'>Privacy</a></li>
 										<li role="separator" class="divider"></li>
 										<li>
 											{{> csrf_token}}
@@ -127,9 +129,9 @@
 							</form>
 						{{/user}}
 						{{^user}}
-							<a href='?{{{forms.get.page}}}={{{forms.pages.login}}}' class='loginButtonLink'>
-								<div class='mediaButton loginButton'><img src='{{{page.template_path}}}images/user.png' class='loginButtonImage' /> Log In</div>
-							</a>
+                            <a href='?{{{forms.get.page}}}={{{forms.pages.login}}}' class='loginButtonLink'>
+                                <div class='mediaButton loginButton'><img src='{{{page.template_path}}}images/user.png' class='loginButtonImage' /> Log In</div>
+                            </a>
 						{{/user}}
 					</div>
 				</div>

--- a/template/menu.mustache
+++ b/template/menu.mustache
@@ -43,12 +43,6 @@
 			{{/user}}
 				<li><a href='?{{{forms.get.page}}}={{{forms.pages.rules}}}'>How it works</a></li>
 				<li><a href='?{{{forms.get.page}}}={{{forms.pages.assets}}}'>Assets</a></li>
-				<li><a href='?{{{forms.get.page}}}={{{forms.pages.privacy}}}'>Privacy</a></li>
-			{{#user}}
-				{{^cookies.is_streamer}}
-					<li><a href='?{{{forms.get.page}}}={{{forms.pages.userdata}}}'>User data</a></li>
-				{{/cookies.is_streamer}}
-			{{/user}}
 
 			<li class="mainmenu-separator">Browse</li>
 			<li><a href='?{{{forms.get.page}}}={{{forms.pages.entries}}}'>{{CONFIG.VALUES.GAME_PHRASE_PLURAL}}</a></li>

--- a/template/register.mustache
+++ b/template/register.mustache
@@ -1,6 +1,6 @@
 <h1 class="pageHeading">Register an account</h1>
 <div class="pageDescription">
-	Register an account by providing a username and password. If you already have an account <a href='?{{{forms.get.page}}}={{{forms.pages.login}}}'>log in</a> instead.
+	Register an account by providing a username and password. Have a look at the <a href='?{{{forms.get.page}}}={{{forms.pages.privacy}}}'>Privacy</a> page for details on what we store and why. If you already have an account <a href='?{{{forms.get.page}}}={{{forms.pages.login}}}'>log in</a> instead.
 </div>
 
 <form method='post'>


### PR DESCRIPTION
- Moves "Privacy" button from left menu to user dropdown, and to the register page
- Moves "User Data" button from left menu to user dropdown (Renamed to "Your data")

![image](https://user-images.githubusercontent.com/1364475/128757166-6db3ec29-6817-4415-89d8-6ded328328d4.png)

![2021-08-09_19-38-38_chrome](https://user-images.githubusercontent.com/1364475/128757187-8636a391-285d-4d9c-bbc5-bf4592cc1a41.png)
